### PR TITLE
Upgrade to rand 0.8.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ documentation = "https://docs.rs/mapgen"
 edition = "2018"
 
 [dependencies]
-rand = "0.7"
+rand = "0.8"

--- a/src/random.rs
+++ b/src/random.rs
@@ -41,7 +41,7 @@ mod tests {
 
     #[test]
     fn test_range_average() {
-        let num_op = 1000;
+        let num_op = 10000;
         let mut rng = StdRng::seed_from_u64(1000);
         let xs: Vec<usize> = (0..num_op).map(|_| rng.random_range(5, 10)).collect();
         let mean = xs.iter().sum::<usize>() / num_op;


### PR DESCRIPTION
There is a failing test: src/random.rs:50. If you have any insight on to why this is failing, I'll gladly fix it. Looks like it is averaging a random sequence, which seems a bit fragile to me as it gets 6 rather than 7, though the min and max seem right. But I need rand 0.8, so figured I'd submit a PR and use my fork until this lands.

Thanks!