### PR TITLE
Add ability to associate arbitrary `BuilderData` with maps.

### DIFF
--- a/demo/src/lib.rs
+++ b/demo/src/lib.rs
@@ -1,7 +1,7 @@
 use wasm_bindgen::prelude::*;
 use web_sys;
 use rand::prelude::*;
-use mapgen::{Map, MapBuilder, geometry::Point};
+use mapgen::{Map, MapBuilder, NoData, geometry::Point};
 use mapgen::filter::*;
 use mapgen::metric;
 
@@ -19,7 +19,7 @@ pub struct World {
     width: u32,
     height: u32,
     tiles: Vec<Cell>,
-    map: Map,
+    map: Map<NoData>,
 }
 
 #[wasm_bindgen]
@@ -32,7 +32,7 @@ pub struct Position {
 #[wasm_bindgen]
 impl World {
     
-    fn new(width: u32, height: u32, map: Map) -> World {
+    fn new(width: u32, height: u32, map: Map<NoData>) -> World {
         let tiles = (0..map.tiles.len())
             .map(|i| if map.tiles[i].is_walkable() {Cell::Floor} else {Cell::Wall})
             .collect();
@@ -176,7 +176,7 @@ impl World {
         div.set_inner_html(&info);
     }
     
-    fn print_map_metrics(map: &Map) {
+    fn print_map_metrics(map: &Map<NoData>) {
         let window = web_sys::window().expect("no global `window` exists");
         let document = window.document().expect("should have a document on window");
         let div = document.get_element_by_id("map-metrics").expect("Need div with id: map-metrics");

--- a/examples/bsp_interior.rs
+++ b/examples/bsp_interior.rs
@@ -4,7 +4,7 @@ use mapgen::*;
 
 fn main() {
     let mut rng = StdRng::seed_from_u64(907647352);
-    let gen = BspInterior::new();
+    let gen = BspInterior::<NoData>::new();
     let map = gen.modify_map(&mut rng, &Map::new(20, 10));
     println!("{:}", &map);
 }

--- a/examples/bsp_rooms.rs
+++ b/examples/bsp_rooms.rs
@@ -6,7 +6,7 @@ use mapgen::*;
 fn main() {
     let system_time = SystemTime::now().duration_since(UNIX_EPOCH).expect("Can't access system time");
     let mut rng = StdRng::seed_from_u64(system_time.as_millis() as u64);
-    let gen = BspRooms::new();
+    let gen = BspRooms::<NoData>::new();
     let map = gen.modify_map(&mut rng, &Map::new(80, 50));
     println!("{:}", &map);
 }

--- a/examples/builder_data.rs
+++ b/examples/builder_data.rs
@@ -1,0 +1,35 @@
+use mapgen::{
+    filter::{
+        AreaStartingPosition, CellularAutomata, CullUnreachable, NoiseGenerator, XStart, YStart,
+    },
+    BuilderData, MapBuilder, MapFilter,
+};
+
+#[derive(Clone, Default)]
+struct MyData {
+    value: usize,
+}
+
+impl BuilderData for MyData {}
+
+struct IncrementData;
+
+impl<D: BuilderData> MapFilter<D> for IncrementData {
+    fn modify_map(&self, rng: &mut rand::prelude::StdRng, map: &mapgen::Map<D>) -> mapgen::Map<D> {
+        let map = map.clone();
+        map.data.value += 1;
+        map
+    }
+}
+
+fn main() {
+    let map = MapBuilder::<MyData>::new(20, 20)
+        .with(NoiseGenerator::uniform())
+        .with(CellularAutomata::new())
+        .with(AreaStartingPosition::new(XStart::CENTER, YStart::CENTER))
+        .with(CullUnreachable::new())
+        .with(Box::new(IncrementData))
+        .build();
+
+    println!("{:}", &map);
+}

--- a/examples/example1.rs
+++ b/examples/example1.rs
@@ -1,5 +1,6 @@
 use mapgen::{
     MapBuilder,
+    NoData,
     filter::{
         NoiseGenerator, 
         CellularAutomata,
@@ -12,7 +13,7 @@ use mapgen::{
 
 
 fn main() {
-    let map = MapBuilder::new(20, 20)
+    let map = MapBuilder::<NoData>::new(20, 20)
         .with(NoiseGenerator::uniform())
         .with(CellularAutomata::new())
         .with(AreaStartingPosition::new(XStart::CENTER, YStart::CENTER))

--- a/src/filter/distant_exit.rs
+++ b/src/filter/distant_exit.rs
@@ -5,7 +5,9 @@
 //! 
 
 use std::f32;
+use std::marker::PhantomData;
 use rand::prelude::StdRng;
+use crate::BuilderData;
 use crate::geometry::Point;
 use crate::MapFilter;
 use crate::Map;
@@ -13,21 +15,25 @@ use crate::dijkstra::DijkstraMap;
 
 
 /// Add exist position to the map based on the distance from the start point.
-pub struct DistantExit {} 
+pub struct DistantExit<D: BuilderData> {
+    phantom: PhantomData<D>,
+}
 
-impl MapFilter for DistantExit {
-    fn modify_map(&self, _: &mut StdRng, map: &Map)  -> Map {
+impl<D: BuilderData> MapFilter<D> for DistantExit<D> {
+    fn modify_map(&self, _: &mut StdRng, map: &Map<D>)  -> Map<D> {
         self.build(map)
     }
 }
 
-impl DistantExit {
+impl<D: BuilderData> DistantExit<D> {
     #[allow(dead_code)]
-    pub fn new() -> Box<DistantExit> {
-        Box::new(DistantExit{})
+    pub fn new() -> Box<DistantExit<D>> {
+        Box::new(DistantExit {
+            phantom: PhantomData,
+        })
     }
 
-    fn build(&self, map: &Map) -> Map {
+    fn build(&self, map: &Map<D>) -> Map<D> {
         let mut new_map = map.clone();
 
         let mut best_idx = 0;
@@ -55,7 +61,7 @@ mod tests {
     use super::*;
     use super::MapFilter;
     use crate::geometry::Point;
-    use crate::map::Map;
+    use crate::map::{Map, NoData};
 
     #[test]
     fn test_exit() {
@@ -65,7 +71,7 @@ mod tests {
         #  #     #
         ##########
         ";
-        let mut map = Map::from_string(map_str);
+        let mut map = Map::<NoData>::from_string(map_str);
         map.starting_point = Some(Point::new(9, 2));
 
         let modifier = DistantExit::new();

--- a/src/filter/noise_generator.rs
+++ b/src/filter/noise_generator.rs
@@ -4,11 +4,11 @@
 //! Example usage:
 //! ```
 //! use rand::prelude::*;
-//! use mapgen::{Map, MapFilter};
+//! use mapgen::{Map, MapFilter, NoData};
 //! use mapgen::filter::NoiseGenerator;
 //! 
 //! let mut rng = StdRng::seed_from_u64(100);
-//! let gen = NoiseGenerator::uniform();
+//! let gen = NoiseGenerator::<NoData>::uniform();
 //! let map = gen.modify_map(&mut rng, &Map::new(80, 50));
 //! 
 //! assert_eq!(map.width, 80);
@@ -16,39 +16,44 @@
 //! ```
 //! 
 
+use std::marker::PhantomData;
+
 use rand::prelude::*;
 use crate::MapFilter;
-use crate::{Map, Tile};
+use crate::{BuilderData, Map, Tile};
 
 
 /// Map noise generator
-pub struct NoiseGenerator {
+pub struct NoiseGenerator<D: BuilderData> {
     prob: f32,
+    phantom: PhantomData<D>,
 }
 
-impl MapFilter for NoiseGenerator {
-    fn modify_map(&self, rng: &mut StdRng, map: &Map)  -> Map {
+impl<D: BuilderData> MapFilter<D> for NoiseGenerator<D> {
+    fn modify_map(&self, rng: &mut StdRng, map: &Map<D>)  -> Map<D> {
         self.build(map, rng)
     }
 }
 
-impl NoiseGenerator {
+impl<D: BuilderData> NoiseGenerator<D> {
     /// Create noise with custom probability
-    pub fn new(prob: f32) -> Box<NoiseGenerator> {
+    pub fn new(prob: f32) -> Box<NoiseGenerator<D>> {
         Box::new(NoiseGenerator {
             prob,
+            phantom: PhantomData,
         })
     }
 
     /// Create uniform noise (Probablity 0.5)
-    pub fn uniform() -> Box<NoiseGenerator> {
+    pub fn uniform() -> Box<NoiseGenerator<D>> {
         Box::new(NoiseGenerator {
             prob: 0.5,
+            phantom: PhantomData,
         })
     }
 
     /// Generate map
-    fn build(&self, map: &Map, rng: &mut StdRng) -> Map {
+    fn build(&self, map: &Map<D>, rng: &mut StdRng) -> Map<D> {
         let mut new_map = map.clone();
         let p = (self.prob * 100.0) as u32;
         for y in 1..new_map.height-1 {

--- a/src/filter/rooms_corridors_nearest.rs
+++ b/src/filter/rooms_corridors_nearest.rs
@@ -1,26 +1,32 @@
 //! Connect nearest rooms on the map with corridors
 //! 
 use rand::prelude::StdRng;
+use crate::BuilderData;
 use crate::MapFilter;
 use crate::Map;
 use std::collections::HashSet;
+use std::marker::PhantomData;
 
 
-pub struct NearestCorridors {}
+pub struct NearestCorridors<D: BuilderData> {
+    phantom: PhantomData<D>,
+}
 
-impl MapFilter for NearestCorridors {
-    fn modify_map(&self, _: &mut StdRng, map: &Map)  -> Map {
+impl<D: BuilderData> MapFilter<D> for NearestCorridors<D> {
+    fn modify_map(&self, _: &mut StdRng, map: &Map<D>)  -> Map<D> {
         self.corridors(map)
     }
 }
 
-impl NearestCorridors {
+impl<D: BuilderData> NearestCorridors<D> {
 
-    pub fn new() -> Box<NearestCorridors> {
-        Box::new(NearestCorridors{})
+    pub fn new() -> Box<NearestCorridors<D>> {
+        Box::new(NearestCorridors {
+            phantom: PhantomData,
+        })
     }
 
-    fn corridors(&self, map: &Map) -> Map {
+    fn corridors(&self, map: &Map<D>) -> Map<D> {
         let mut new_map = map.clone();
 
         let mut connected : HashSet<usize> = HashSet::new();

--- a/src/filter/simple_rooms.rs
+++ b/src/filter/simple_rooms.rs
@@ -6,11 +6,11 @@
 //! Example generator usage:
 //! ```
 //! use rand::prelude::*;
-//! use mapgen::{MapFilter, Map};
+//! use mapgen::{MapFilter, Map, NoData};
 //! use mapgen::filter::SimpleRooms;
 //! 
 //! let mut rng = StdRng::seed_from_u64(100);
-//! let gen = SimpleRooms::new();
+//! let gen = SimpleRooms::<NoData>::new();
 //! let map = gen.modify_map(&mut rng, &Map::new(80, 50));
 //! 
 //! assert_eq!(map.width, 80);
@@ -18,36 +18,41 @@
 //! ```
 //! 
 
+use std::marker::PhantomData;
+
 use rand::prelude::*;
+use crate::BuilderData;
 use crate::MapFilter;
 use crate::geometry::Rect;
 use crate::random::Rng;
 use crate::Map;
 
 
-pub struct SimpleRooms {
+pub struct SimpleRooms<D: BuilderData> {
     max_rooms: usize,
     min_room_size: usize,
     max_room_size: usize,
+    phantom: PhantomData<D>,
 }
 
-impl MapFilter for SimpleRooms {
-    fn modify_map(&self, rng: &mut StdRng, map: &Map)  -> Map {
+impl<D: BuilderData> MapFilter<D> for SimpleRooms<D> {
+    fn modify_map(&self, rng: &mut StdRng, map: &Map<D>)  -> Map<D> {
         self.build_rooms(map, rng)
     }
 }
 
 
-impl SimpleRooms {
-    pub fn new() -> Box<SimpleRooms> {
+impl<D: BuilderData> SimpleRooms<D> {
+    pub fn new() -> Box<SimpleRooms<D>> {
         Box::new(SimpleRooms{
             max_rooms: 30,
             min_room_size: 6,
-            max_room_size: 10
+            max_room_size: 10,
+            phantom: PhantomData,
         })
     }
 
-    fn build_rooms(&self, map: &Map, rng : &mut StdRng) -> Map {
+    fn build_rooms(&self, map: &Map<D>, rng : &mut StdRng) -> Map<D> {
         let mut new_map = map.clone();
 
         // Create room dimensions

--- a/src/filter/voronoi.rs
+++ b/src/filter/voronoi.rs
@@ -1,11 +1,11 @@
 //! Example generator usage:
 //! ```
 //! use rand::prelude::*;
-//! use mapgen::{Map, MapFilter};
+//! use mapgen::{Map, MapFilter, NoData};
 //! use mapgen::filter::VoronoiHive;
 //! 
 //! let mut rng = StdRng::seed_from_u64(100);
-//! let gen = VoronoiHive::new();
+//! let gen = VoronoiHive::<NoData>::new();
 //! let map = gen.modify_map(&mut rng, &Map::new(80, 50));
 //! 
 //! assert_eq!(map.width, 80);
@@ -13,34 +13,38 @@
 //! ```
 //! 
 
+use std::marker::PhantomData;
+
 use rand::prelude::*;
 use crate::MapFilter;
 use crate::{
-    map::{Map, Tile},
+    map::{BuilderData, Map, Tile},
     random::Rng,
     geometry::Point,
 };
 
 
-pub struct VoronoiHive {
+pub struct VoronoiHive<D: BuilderData> {
     n_seeds: usize,
+    phantom: PhantomData<D>,
 }
 
 
-impl MapFilter for VoronoiHive {
-    fn modify_map(&self, rng: &mut StdRng, map: &Map)  -> Map {
+impl<D: BuilderData> MapFilter<D> for VoronoiHive<D> {
+    fn modify_map(&self, rng: &mut StdRng, map: &Map<D>)  -> Map<D> {
         self.build(rng, map)
     }
 }
 
-impl VoronoiHive {
-    pub fn new() -> Box<VoronoiHive> {
+impl<D: BuilderData> VoronoiHive<D> {
+    pub fn new() -> Box<VoronoiHive<D>> {
         Box::new(VoronoiHive{
             n_seeds: 64,
+            phantom: PhantomData,
         })
     }
 
-    fn build(&self, rng: &mut StdRng, map: &Map) -> Map {
+    fn build(&self, rng: &mut StdRng, map: &Map<D>) -> Map<D> {
         let mut new_map = map.clone();
         let seeds = self.generate_seeds(rng, map.width, map.height);
 

--- a/src/metric.rs
+++ b/src/metric.rs
@@ -4,6 +4,7 @@
 //! and the provide generator score as an average.
 //! 
 
+use super::BuilderData;
 use super::map::Map;
 use super::dijkstra::DijkstraMap;
 
@@ -11,7 +12,7 @@ use super::dijkstra::DijkstraMap;
 /// This metric calculates the percentage of walkable cells (Floor).
 /// If this number is very low (like < 10%) then it means that the map 
 /// is probably to degenerated and shouldn't be used
-pub fn density(map: &Map) -> f32 {
+pub fn density<D>(map: &Map<D>) -> f32 {
     let floor_count = map.tiles.iter()
         .filter(|&t| t.is_walkable())
         .count();
@@ -22,7 +23,7 @@ pub fn density(map: &Map) -> f32 {
 /// Calculate the length of the shortes path from the starting point
 /// to the exit.
 /// If this path is very short, then the map is probably degenerated.
-pub fn path_length(map: &Map) -> f32 {
+pub fn path_length<D: BuilderData>(map: &Map<D>) -> f32 {
     if map.starting_point.is_none() {
         return 0.0
     }
@@ -43,12 +44,12 @@ pub fn path_length(map: &Map) -> f32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::geometry::Point;
+    use crate::{geometry::Point, map::NoData};
 
 
     #[test]
     fn test_density_no_floor() {
-        let map = Map::new(10, 10);
+        let map = Map::<NoData>::new(10, 10);
         let score = density(&map);
         assert_eq!(score, 0.0);
     }
@@ -60,7 +61,7 @@ mod tests {
             #   ##   #
             ##########
             ";
-        let map = Map::from_string(map_str);
+        let map = Map::<NoData>::from_string(map_str);
         let score = density(&map);
         assert_eq!(score, 0.2);
     }
@@ -72,7 +73,7 @@ mod tests {
             #   ##   #
             ##########
             ";
-        let map = Map::from_string(map_str);
+        let map = Map::<NoData>::from_string(map_str);
         let score = path_length(&map);
         assert_eq!(score, 0.0);
     }
@@ -85,7 +86,7 @@ mod tests {
             #        #
             ##########
             ";
-        let mut map = Map::from_string(map_str);
+        let mut map = Map::<NoData>::from_string(map_str);
         map.starting_point = Some(Point::new(1,1));
         map.exit_point = Some(Point::new(8,1));
 


### PR DESCRIPTION
I'm finding that, for best results, I need to integrate everything into my map generation process. So for instance, object/monster spawns need to run as a filter so they can influence future steps.

This associates a `Clone + Default` type with maps and makes it available to filters. `NoData` exists for the current behavior.

All examples/tests/demos have been updated accordingly.
