### PR TITLE
For non-configurable filters, mark fields as `pub`

### DIFF
--- a/src/filter/bsp_interior.rs
+++ b/src/filter/bsp_interior.rs
@@ -28,7 +28,7 @@ use crate::MapBuffer;
 
 
 pub struct BspInterior {
-    min_room_size: usize,
+    pub min_room_size: usize,
 }
 
 impl MapFilter for BspInterior {

--- a/src/filter/bsp_rooms.rs
+++ b/src/filter/bsp_rooms.rs
@@ -26,7 +26,7 @@ use crate::MapBuffer;
 
 
 pub struct BspRooms {
-    max_split: usize,
+    pub max_split: usize,
 }
 
 impl MapFilter for BspRooms {

--- a/src/filter/cellular_automata.rs
+++ b/src/filter/cellular_automata.rs
@@ -28,7 +28,7 @@ use crate::MapBuffer;
 
 /// Map filter
 pub struct CellularAutomata {
-    num_iteraction: u32,
+    pub num_iteraction: u32,
 }
 
 impl MapFilter for CellularAutomata {

--- a/src/filter/simple_rooms.rs
+++ b/src/filter/simple_rooms.rs
@@ -26,9 +26,9 @@ use crate::MapBuffer;
 
 
 pub struct SimpleRooms {
-    max_rooms: usize,
-    min_room_size: usize,
-    max_room_size: usize,
+    pub max_rooms: usize,
+    pub min_room_size: usize,
+    pub max_room_size: usize,
 }
 
 impl MapFilter for SimpleRooms {

--- a/src/filter/voronoi.rs
+++ b/src/filter/voronoi.rs
@@ -23,7 +23,7 @@ use crate::{
 
 
 pub struct VoronoiHive {
-    n_seeds: usize,
+    pub n_seeds: usize,
 }
 
 


### PR DESCRIPTION
I would like to be able to set all fields for the varying filters - and I personally only like defining `new` for structs if more than just copying fields into a struct has to be performed to initialize it hence why I've just marked the fields as `pub`.